### PR TITLE
Simplify isodate-traverse and explicitly recurse

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4
+    version: 8
   environment:
     NPM_CONFIG_PROGRESS: false
     NPM_CONFIG_SPIN: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,6 @@ var isodate = require('@segment/isodate');
 /**
  * Expose `traverse`.
  */
-
 module.exports = traverse;
 
 /**
@@ -17,10 +16,8 @@ module.exports = traverse;
  * @param {Boolean} strict - only convert strings with year, month, and date
  * @return {Object}
  */
-
 function traverse(input, strict) {
-  if (strict === undefined)
-    strict = true;
+  if (strict === undefined) strict = true;
   if (type(input) === 'object') {
     return traverseObject(input, strict);
   } else if (type(input) === 'array') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var type = require('component-type');
-var each = require('component-each');
 var isodate = require('@segment/isodate');
 
 /**
@@ -11,65 +10,51 @@ var isodate = require('@segment/isodate');
 module.exports = traverse;
 
 /**
- * Traverse an object or array, and return a clone with all ISO strings parsed
- * into Date objects.
+ * Recursively traverse an object or array, and convert
+ * all ISO date strings parse into Date objects.
  *
- * @param {Object} obj
+ * @param {Object} input - object, array, or string to convert
+ * @param {Boolean} strict - only convert strings with year, month, and date
  * @return {Object}
  */
 
 function traverse(input, strict) {
-  if (strict === undefined) strict = true;
-
-  if (type(input) === 'object') return object(input, strict);
-  if (type(input) === 'array') return array(input, strict);
+  if (strict === undefined)
+    strict = true;
+  if (type(input) === 'object') {
+    return traverseObject(input, strict);
+  } else if (type(input) === 'array') {
+    return traverseArray(input, strict);
+  } else if (isodate.is(input, strict)) {
+    return isodate.parse(input);
+  }
   return input;
 }
 
 /**
- * Object traverser.
+ * Object traverser helper function.
  *
- * @param {Object} obj
- * @param {Boolean} strict
+ * @param {Object} obj - object to traverse
+ * @param {Boolean} strict - only convert strings with year, month, and date
  * @return {Object}
  */
-
-function object(obj, strict) {
-  // 'each' utility uses obj.length to check whether the obj is array. To avoid incorrect classification, wrap call to 'each' with rename of obj.length
-  if (obj.length && typeof obj.length === 'number' && !(obj.length - 1 in obj)) { // cross browser compatible way of checking has length and is not array
-    obj.lengthNonArray = obj.length;
-    delete obj.length;
-  }
-  each(obj, function(key, val) {
-    if (isodate.is(val, strict)) {
-      obj[key] = isodate.parse(val);
-    } else if (type(val) === 'object' || type(val) === 'array') {
-      traverse(val, strict);
-    }
+function traverseObject(obj, strict) {
+  Object.keys(obj).forEach(function(key) {
+    obj[key] = traverse(obj[key], strict);
   });
-  // restore obj.length if it was renamed
-  if (obj.lengthNonArray) {
-    obj.length = obj.lengthNonArray;
-    delete obj.lengthNonArray;
-  }
   return obj;
 }
 
 /**
- * Array traverser.
+ * Array traverser helper function
  *
- * @param {Array} arr
- * @param {Boolean} strict
+ * @param {Array} arr - array to traverse
+ * @param {Boolean} strict - only convert strings with year, month, and date
  * @return {Array}
  */
-
-function array(arr, strict) {
-  each(arr, function(val, x) {
-    if (type(val) === 'object') {
-      traverse(val, strict);
-    } else if (isodate.is(val, strict)) {
-      arr[x] = isodate.parse(val);
-    }
+function traverseArray(arr, strict) {
+  arr.forEach(function(value, index) {
+    arr[index] = traverse(value, strict);
   });
   return arr;
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",
+    "@segment/to-iso-string": "0.0.2",
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "equals": "^1.0.1",
     "eslint": "^2.9.0",
     "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-react": "^4.3.0",
     "eslint-plugin-require-path-exists": "^1.1.5",
     "istanbul": "^0.4.3",
     "karma": "^0.13.22",
@@ -49,7 +51,6 @@
     "mocha": "^2.2.5",
     "phantomjs-prebuilt": "^2.1.7",
     "proclaim": "^3.4.1",
-    "to-iso-string": "0.0.2",
     "watchify": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/segmentio/isodate-traverse#readme",
   "dependencies": {
     "@segment/isodate": "^1.0.0",
-    "component-each": "^0.2.6",
     "component-type": "^1.2.1"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
 
 var assert = require('proclaim');
 var traverse = require('../lib');
-var toISOString = require('to-iso-string');
+var toISOString = require('@segment/to-iso-string');
 
 describe('isodate-traverse', function() {
   it('should convert isostrings', function() {


### PR DESCRIPTION
This removes `component-each` as a dependency and removes a lot of code hedging around its behavior.